### PR TITLE
Travis-ci: added support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,11 @@ language: python
 
 # workaround to make travis work with python3.7
 # https://github.com/travis-ci/travis-ci/issues/9069#issuecomment-425720905
+arch:
+  - amd64
+  - ppc64le
 sudo: required
 dist: xenial
-
 python:
   - '3.5'
   - '3.6'
@@ -12,6 +14,7 @@ python:
   - 'nightly'
 
 install:
+  - pip install --upgrade pytest
   - pip install -e .['dev']
 
 script:


### PR DESCRIPTION
Hi,
I have added support for ppc64le build on travis-ci in the branch . The travis-ci build log can be tracked on the link :https://travis-ci.com/github/sanjaymsh/dotenv-cli/builds/187387570 . I believe it is ready for the final review and merge.
Please have a look on it and if everything looks fine for you then please approve it for merge.

Thanks !!