### PR TITLE
Send a SIGKILL after 3 seconds if SIGTERM didn't stop the child process

### DIFF
--- a/dotenv_cli/core.py
+++ b/dotenv_cli/core.py
@@ -1,7 +1,8 @@
+import atexit
 import logging
 import os
 from subprocess import Popen  # , PIPE, STDOUT
-
+from time import sleep
 
 logger = logging.getLogger(__name__)
 
@@ -84,4 +85,13 @@ def run_dotenv(filename, command):
         env=env,
     )
     _, _ = proc.communicate()
+
+    def terminate_child(target=proc):
+        target.terminate()
+        sleep(3)
+        if target.poll() is not None:
+            logger.warning('Process survived the SIGTERM, killing it!')
+            target.kill()
+        atexit.register(terminate_child)
+
     return proc.returncode


### PR DESCRIPTION
As per title, when the child program ignores the `SIGTERM` (for example the user presses Ctrl+C while the child process is running a psycopg2 query) now dotenv-cli exits but leaves the child running in background.
With this change, after 3 seconds if the program is still running it is definitely killed using SIGKILL.