### PR TITLE
Replace executable when the environment is set, no forking

### DIFF
--- a/dotenv_cli/core.py
+++ b/dotenv_cli/core.py
@@ -83,7 +83,8 @@ def run_dotenv(filename: str, command: list[str]) -> int:
     Returns
     -------
     int
-        the return value
+        The exit status code in Windows. In POSIX-compatible systems, the
+        function does not return normally.
 
     """
     # read dotenv
@@ -92,6 +93,10 @@ def run_dotenv(filename: str, command: list[str]) -> int:
     # update env
     env = os.environ.copy()
     env.update(dotenv)
+
+    # in POSIX, we replace the current process and all is done
+    if os.name == 'posix':
+        os.execvpe(command[0], command, env)
 
     # execute
     proc = Popen(


### PR DESCRIPTION
 * There is no need to fork and wait the child process to end.
 * Moreover, our dangling process with the Python interpreter masked signals sent from terminal. For example, Ctrl-C on terminal reached the running program not as SIGINT but as SIGTERM.